### PR TITLE
feat: a draggable abstraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: node_js
 cache:
   directories:
@@ -9,10 +9,14 @@ node_js:
   - '4'
 before_install:
   - npm i -g npm@^3.8.0
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
+  - export CHROME_BIN=/usr/bin/google-chrome
 before_script:
   - "npm prune"
   - "npm update"
-  - "export CHROME_BIN=chromium-browser"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 3" # give xvfb some time to start

--- a/e2e/draggable/Draggable.jsx
+++ b/e2e/draggable/Draggable.jsx
@@ -1,0 +1,190 @@
+import Draggable from '../../src/Draggable';
+import { mousedown, mousemove, mouseup, touchstart, touchmove, touchend, gesturestart, gesturemove } from '../interaction';
+
+describe('Draggable', () => {
+    let el;
+    let draggable;
+    let handler;
+
+    beforeEach(() => {
+        el = document.createElement("div");
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        draggable && draggable.destroy();
+        document.body.removeChild(el);
+    });
+
+    describe("Press", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable(el, {
+                press: handler
+            });
+        });
+
+        it('executes press with coordinates on mousedown', () => {
+            mousedown(el, 100, 200);
+
+            const args = handler.calls.mostRecent().args[0];
+
+            expect(args.pageX).toEqual(100);
+            expect(args.pageY).toEqual(200);
+        });
+
+        it("executes press with coordinates on touchstart", () => {
+            touchstart(el, 100, 200);
+
+            const args = handler.calls.mostRecent().args[0];
+
+            expect(args.pageX).toEqual(100);
+            expect(args.pageY).toEqual(200);
+        });
+
+        it("ignores multi touches", () => {
+            touchstart(el, 100, 200);
+            gesturestart(el, 100, 200, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Mouse Drag", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onDrag");
+
+            draggable = new Draggable(el, {
+                drag: handler
+            });
+
+            mousedown(el, 100, 200);
+            mousemove(el, 101, 201);
+        });
+
+        it("triggers drag for down + move", () => {
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("stops listening when released", () => {
+            mouseup(el, 101, 201);
+            mousemove(el, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Touch drag", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onDrag");
+
+            draggable = new Draggable(el, {
+                drag: handler
+            });
+
+            touchstart(el, 100, 200);
+            touchmove(el, 101, 201);
+        });
+
+        it("triggers drag for down + move", () => {
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("disposes drag handlers properly", () => {
+            draggable.destroy();
+            draggable = null;
+
+            touchmove(el, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+
+        it("ignores gestures", () => {
+            gesturemove(el, 101, 201, 102, 202);
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Mouse up", () => {
+        it("triggers release", () => {
+            handler = jasmine.createSpy("onRelease");
+
+            draggable = new Draggable(el, {
+                release: handler
+            });
+
+            mousedown(el, 99, 200);
+            mousemove(el, 101, 201);
+            mouseup(el, 101, 201);
+            expect(handler).toHaveBeenCalled();
+        });
+    });
+
+    describe("Touch end", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onRelease");
+
+            draggable = new Draggable(el, {
+                release: handler
+            });
+
+            touchstart(el, 100, 200);
+            touchmove(el, 101, 201);
+            touchend(el, 101, 201);
+        });
+
+        it("triggers release on touchend", () => {
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("disposes drag handlers properly", () => {
+            draggable.destroy();
+            draggable = null;
+
+            touchend(el, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Emulated mouse events', () => {
+        it("ignores mouse after touch", () => {
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable(el, {
+                press: handler,
+                release: handler
+            });
+
+            // mouse events are triggered
+            touchstart(el, 100, 200);
+            touchend(el, 100, 200);
+            mousedown(el, 100, 200);
+            mouseup(el, 100, 200);
+
+            expect(handler).toHaveBeenCalledTimes(2);
+        });
+
+        it("restores mouse listeners after a while", () => {
+            const clock = jasmine.clock();
+            clock.install();
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable(el, {
+                press: handler,
+                release: handler
+            });
+
+            // mouse events are triggered
+            touchstart(el, 100, 200);
+            touchend(el, 100, 200);
+            clock.tick(20000);
+            mousedown(el, 100, 200);
+            mouseup(el, 100, 200);
+
+            expect(handler).toHaveBeenCalledTimes(4);
+            clock.uninstall();
+        });
+    });
+});

--- a/e2e/interaction.jsx
+++ b/e2e/interaction.jsx
@@ -1,0 +1,69 @@
+/* eslint max-params: [2, 5] */
+
+const aMouseEvent = (type, x, y) =>
+        new MouseEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: x,
+            clientY: y
+        });
+
+const aTouch = (el, x, y, id) =>
+    new Touch({
+        identifier: id,
+        target: el,
+        pageX: x,
+        pageY: y
+    });
+
+const aTouchEvent = (type, touches) =>
+    new TouchEvent(type, {
+        touches: (type === "touchend" ? [] : touches),
+        changedTouches: touches
+    });
+
+export function mousedown(element, x, y) {
+    element.dispatchEvent(aMouseEvent("mousedown", x, y));
+}
+
+export function mousemove(element, x, y) {
+    element.dispatchEvent(aMouseEvent("mousemove", x, y));
+}
+
+export function mouseup(element, x, y) {
+    element.dispatchEvent(aMouseEvent("mouseup", x, y));
+}
+
+export function touchstart(element, x, y) {
+    element.dispatchEvent(aTouchEvent("touchstart", [ aTouch(element, x, y, 100) ]));
+}
+
+export function touchmove(element, x, y) {
+    element.dispatchEvent(aTouchEvent("touchmove", [ aTouch(element, x, y, 100) ]));
+}
+
+export function touchend(element, x, y) {
+    element.dispatchEvent(aTouchEvent("touchend", [ aTouch(element, x, y, 100) ]));
+}
+
+export function gesturestart(element, x1, y1, x2, y2) {
+    element.dispatchEvent(aTouchEvent("touchstart", [
+        aTouch(element, x1, y1, 100),
+        aTouch(element, x1, y2, 101)
+    ]));
+}
+
+export function gesturemove(element, x1, y1, x2, y2) {
+    element.dispatchEvent(aTouchEvent("touchmove", [
+        aTouch(element, x1, y1, 100),
+        aTouch(element, x1, y2, 101)
+    ]));
+}
+
+export function gestureend(element, x1, y1, x2, y2) {
+    element.dispatchEvent(aTouchEvent("touchend", [
+        aTouch(element, x1, y1, 100),
+        aTouch(element, x1, y2, 101)
+    ]));
+}

--- a/examples/draggable.html
+++ b/examples/draggable.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <div style="width: 2000px; height: 2000px; touch-action: pan-y">
+        <div id="app"></div>
+    </div>
+    <script src="draggable.js"></script>
+</body>
+</html>

--- a/examples/draggable.jsx
+++ b/examples/draggable.jsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import Draggable from "../src/Draggable";
+
+class DraggableDiv extends React.Component {
+    componentDidMount() {
+        this.d = new Draggable(this.el, {
+            press: (e) => { console.log("press", e) },
+            drag: (e) => { console.log("drag", e) },
+            release: (e) => { console.log("release", e) }
+        });
+    }
+
+    render() {
+        return (
+            <div
+                ref={(c) => this.el = c}
+                style={{ width: 399, height: 400, background: "red" }}
+            ></div>);
+    }
+}
+ReactDOM.render(
+    <DraggableDiv />,
+    document.getElementById('app')
+);

--- a/src/Draggable.jsx
+++ b/src/Draggable.jsx
@@ -1,0 +1,100 @@
+const proxy = (a, b) => (e) => b(a(e));
+
+const bind = (el, event, callback) =>
+    el.addEventListener(event, callback);
+
+const unbind = (el, event, callback) =>
+    el.removeEventListener(event, callback);
+
+const touchRegExp = /touch/;
+
+function normalizeEvent(e) {
+    if (e.type.match(touchRegExp)) {
+        return {
+            pageX: e.changedTouches[0].pageX,
+            pageY: e.changedTouches[0].pageY,
+            type: e.type
+        };
+    }
+
+    return {
+        pageX: e.pageX,
+        pageY: e.pageY,
+        type: e.type
+    };
+}
+
+const noop = function() { };
+
+// 300ms is the usual mouse interval;
+// However, a weak mobile device under a heavy load may queue mouse events for longer.
+const IGNORE_MOUSE_TIMEOUT = 2000;
+
+export default class Draggable {
+    constructor(element, { press = noop, drag = noop, release = noop }) {
+        this._pressHandler = proxy(normalizeEvent, press);
+        this._dragHandler = proxy(normalizeEvent, drag);
+        this._releaseHandler = proxy(normalizeEvent, release);
+
+        this._element = element;
+        this._ignoreMouse = false;
+
+        bind(element, "mousedown", this._mousedown);
+        bind(element, "touchstart", this._touchstart);
+        bind(element, "touchmove", this._touchmove);
+        bind(element, "touchend", this._touchend);
+    }
+
+    _touchstart = (e) => {
+        if (e.touches.length === 1) {
+            this._pressHandler(e);
+        }
+    };
+
+    _touchmove = (e) => {
+        if (e.touches.length === 1) {
+            this._dragHandler(e);
+        }
+    };
+
+    _touchend = (e) => {
+        // the last finger has been lifted, and the user is not doing gesture.
+        // there might be a better way to handle this.
+        if (e.touches.length === 0 && e.changedTouches.length === 1) {
+            this._releaseHandler(e);
+            this._ignoreMouse = true;
+            setTimeout(this._restoreMouse, IGNORE_MOUSE_TIMEOUT);
+        }
+    };
+
+    _restoreMouse = () =>
+        this._ignoreMouse = false;
+
+    _mousedown = (e) => {
+        if (!this._ignoreMouse) {
+            bind(document, "mousemove", this._mousemove);
+            bind(document, "mouseup", this._mouseup);
+            this._pressHandler(e);
+        }
+    };
+
+    _mousemove = (e) => {
+        this._dragHandler(e);
+    };
+
+    _mouseup = (e) => {
+        unbind(document, "mousemove", this._mousemove);
+        unbind(document, "mouseup", this._mouseup);
+        this._releaseHandler(e);
+    };
+
+    destroy() {
+        unbind(this._element, "mousedown", this._mousedown);
+        unbind(this._element, "touchstart", this._touchstart);
+        unbind(this._element, "touchmove", this._touchmove);
+        unbind(this._element, "touchend", this._touchend);
+
+        this._element = null;
+    }
+}
+

--- a/src/Draggable.jsx
+++ b/src/Draggable.jsx
@@ -67,8 +67,9 @@ export default class Draggable {
         }
     };
 
-    _restoreMouse = () =>
+    _restoreMouse = () => {
         this._ignoreMouse = false;
+    };
 
     _mousedown = (e) => {
         if (!this._ignoreMouse) {


### PR DESCRIPTION
Refers to #22 

We don't deal with pointer events, yet. Mouse events seem to do just fine in Edge/Surface. 

- Works as expected in Android. The slider will need `touch-action: pan-y`. 
- Works well in iOS, but the draggable does not prevent the horizontal scrolling. To be honest, I don't think that we should deal with that. A very simple workaround is to add `ontouchstart='return false'` on the container. And, of course, a better approach would be to specify a viewport meta tag that will size the viewport correctly.

 