### PR TITLE
Slider drag and drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: node_js
 cache:
   directories:
@@ -9,10 +9,14 @@ node_js:
   - '4'
 before_install:
   - npm i -g npm@^3.8.0
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
+  - export CHROME_BIN=/usr/bin/google-chrome
 before_script:
   - "npm prune"
   - "npm update"
-  - "export CHROME_BIN=chromium-browser"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - "sleep 3" # give xvfb some time to start

--- a/e2e/draggable/Draggable.jsx
+++ b/e2e/draggable/Draggable.jsx
@@ -1,0 +1,190 @@
+import Draggable from '../../src/Draggable';
+import { mousedown, mousemove, mouseup, touchstart, touchmove, touchend, gesturestart, gesturemove } from '../interaction';
+
+describe('Draggable', () => {
+    let el;
+    let draggable;
+    let handler;
+
+    beforeEach(() => {
+        el = document.createElement("div");
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        draggable && draggable.destroy();
+        document.body.removeChild(el);
+    });
+
+    describe("Press", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable(el, {
+                press: handler
+            });
+        });
+
+        it('executes press with coordinates on mousedown', () => {
+            mousedown(el, 100, 200);
+
+            const args = handler.calls.mostRecent().args[0];
+
+            expect(args.pageX).toEqual(100);
+            expect(args.pageY).toEqual(200);
+        });
+
+        it("executes press with coordinates on touchstart", () => {
+            touchstart(el, 100, 200);
+
+            const args = handler.calls.mostRecent().args[0];
+
+            expect(args.pageX).toEqual(100);
+            expect(args.pageY).toEqual(200);
+        });
+
+        it("ignores multi touches", () => {
+            touchstart(el, 100, 200);
+            gesturestart(el, 100, 200, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Mouse Drag", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onDrag");
+
+            draggable = new Draggable(el, {
+                drag: handler
+            });
+
+            mousedown(el, 100, 200);
+            mousemove(el, 101, 201);
+        });
+
+        it("triggers drag for down + move", () => {
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("stops listening when released", () => {
+            mouseup(el, 101, 201);
+            mousemove(el, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Touch drag", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onDrag");
+
+            draggable = new Draggable(el, {
+                drag: handler
+            });
+
+            touchstart(el, 100, 200);
+            touchmove(el, 101, 201);
+        });
+
+        it("triggers drag for down + move", () => {
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("disposes drag handlers properly", () => {
+            draggable.destroy();
+            draggable = null;
+
+            touchmove(el, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+
+        it("ignores gestures", () => {
+            gesturemove(el, 101, 201, 102, 202);
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Mouse up", () => {
+        it("triggers release", () => {
+            handler = jasmine.createSpy("onRelease");
+
+            draggable = new Draggable(el, {
+                release: handler
+            });
+
+            mousedown(el, 99, 200);
+            mousemove(el, 101, 201);
+            mouseup(el, 101, 201);
+            expect(handler).toHaveBeenCalled();
+        });
+    });
+
+    describe("Touch end", () => {
+        beforeEach(() => {
+            handler = jasmine.createSpy("onRelease");
+
+            draggable = new Draggable(el, {
+                release: handler
+            });
+
+            touchstart(el, 100, 200);
+            touchmove(el, 101, 201);
+            touchend(el, 101, 201);
+        });
+
+        it("triggers release on touchend", () => {
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("disposes drag handlers properly", () => {
+            draggable.destroy();
+            draggable = null;
+
+            touchend(el, 101, 201);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Emulated mouse events', () => {
+        it("ignores mouse after touch", () => {
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable(el, {
+                press: handler,
+                release: handler
+            });
+
+            // mouse events are triggered
+            touchstart(el, 100, 200);
+            touchend(el, 100, 200);
+            mousedown(el, 100, 200);
+            mouseup(el, 100, 200);
+
+            expect(handler).toHaveBeenCalledTimes(2);
+        });
+
+        it("restores mouse listeners after a while", () => {
+            const clock = jasmine.clock();
+            clock.install();
+            handler = jasmine.createSpy("onPress");
+
+            draggable = new Draggable(el, {
+                press: handler,
+                release: handler
+            });
+
+            // mouse events are triggered
+            touchstart(el, 100, 200);
+            touchend(el, 100, 200);
+            clock.tick(20000);
+            mousedown(el, 100, 200);
+            mouseup(el, 100, 200);
+
+            expect(handler).toHaveBeenCalledTimes(4);
+            clock.uninstall();
+        });
+    });
+});

--- a/e2e/interaction.jsx
+++ b/e2e/interaction.jsx
@@ -1,0 +1,69 @@
+/* eslint max-params: [2, 5] */
+
+const aMouseEvent = (type, x, y) =>
+        new MouseEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: x,
+            clientY: y
+        });
+
+const aTouch = (el, x, y, id) =>
+    new Touch({
+        identifier: id,
+        target: el,
+        pageX: x,
+        pageY: y
+    });
+
+const aTouchEvent = (type, touches) =>
+    new TouchEvent(type, {
+        touches: (type === "touchend" ? [] : touches),
+        changedTouches: touches
+    });
+
+export function mousedown(element, x, y) {
+    element.dispatchEvent(aMouseEvent("mousedown", x, y));
+}
+
+export function mousemove(element, x, y) {
+    element.dispatchEvent(aMouseEvent("mousemove", x, y));
+}
+
+export function mouseup(element, x, y) {
+    element.dispatchEvent(aMouseEvent("mouseup", x, y));
+}
+
+export function touchstart(element, x, y) {
+    element.dispatchEvent(aTouchEvent("touchstart", [ aTouch(element, x, y, 100) ]));
+}
+
+export function touchmove(element, x, y) {
+    element.dispatchEvent(aTouchEvent("touchmove", [ aTouch(element, x, y, 100) ]));
+}
+
+export function touchend(element, x, y) {
+    element.dispatchEvent(aTouchEvent("touchend", [ aTouch(element, x, y, 100) ]));
+}
+
+export function gesturestart(element, x1, y1, x2, y2) {
+    element.dispatchEvent(aTouchEvent("touchstart", [
+        aTouch(element, x1, y1, 100),
+        aTouch(element, x1, y2, 101)
+    ]));
+}
+
+export function gesturemove(element, x1, y1, x2, y2) {
+    element.dispatchEvent(aTouchEvent("touchmove", [
+        aTouch(element, x1, y1, 100),
+        aTouch(element, x1, y2, 101)
+    ]));
+}
+
+export function gestureend(element, x1, y1, x2, y2) {
+    element.dispatchEvent(aTouchEvent("touchend", [
+        aTouch(element, x1, y1, 100),
+        aTouch(element, x1, y2, 101)
+    ]));
+}

--- a/e2e/slider/Slider.jsx
+++ b/e2e/slider/Slider.jsx
@@ -56,15 +56,18 @@ describe('Slider', withRoot(root => {
         expect(ariaText).toEqual('3');
     });
 
-    it('should add k-pressed on track press', () => {
+    it('should add k-pressed on track drag', () => {
         render();
 
         const track = root.find('.k-slider-track')[0];
         const handle = root.find('.k-draghandle');
 
         track.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        document.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
 
         expect(handle.hasClass('k-pressed')).toBeTruthy();
+
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
 
     it('should trigger change on track press', () => {
@@ -86,6 +89,8 @@ describe('Slider', withRoot(root => {
         }));
 
         expect(changeSpy).toHaveBeenCalledWith({ value: props.min });
+
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
 
     it('should trigger change on handle drag', () => {

--- a/e2e/slider/Slider.jsx
+++ b/e2e/slider/Slider.jsx
@@ -4,55 +4,46 @@ import Slider from '../../src/slider/Slider';
 import { withRoot } from 'e2e-utils';
 
 describe('Slider', withRoot(root => {
-    function render() {
-        ReactDOM.render( <Slider {...props} />, root[0]);
-    }
-    let props;
-    it('should resize slider wrapper', () => {
-        props = {
+    function render(options) {
+        const props = Object.assign({
             max: 10,
             min: 0,
             style: { width: 300 },
-            step: 1
-        };
+            smallStep: 1,
+            value: 3,
+            onChange: () => { /*noop*/ }
+        }, options);
+
+        ReactDOM.render(<Slider {...props} />, root[0]);
+    }
+
+    it('should resize slider wrapper', () => {
         render();
+
         const slider = root.find('.k-slider');
+
         expect(slider.width()).toEqual(300);
     });
 
-    it('should resize  wrapper', () => {
-        props = {
-            max: 10,
-            min: 0,
-            style: { width: 300 },
-            step: 1
-        };
+    it('should resize wrapper', () => {
         render();
+
         const track = root.find('.k-slider-track');
+
         expect(track.width()).toEqual(230);
     });
 
     it('should add tabindex attributes', () => {
-        props = {
-            max: 10,
-            min: 0,
-            style: { width: 300 },
-            step: 1
-        };
         render();
+
         const handle = root.find('.k-draghandle');
+
         expect(handle.attr('tabindex')).toEqual('0');
     });
 
     it('should add aria attributes', () => {
-        props = {
-            max: 10,
-            min: 0,
-            style: { width: 300 },
-            step: 1,
-            value: 3
-        };
         render();
+
         const handle = root.find('.k-draghandle');
         const ariaMin = handle.attr('aria-valuemin');
         const ariaMax = handle.attr('aria-valuemax');
@@ -63,5 +54,66 @@ describe('Slider', withRoot(root => {
         expect(ariaMax).toEqual('10');
         expect(ariaNow).toEqual('3');
         expect(ariaText).toEqual('3');
+    });
+
+    it('should add k-pressed on track press', () => {
+        render();
+
+        const track = root.find('.k-slider-track')[0];
+        const handle = root.find('.k-draghandle');
+
+        track.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        expect(handle.hasClass('k-pressed')).toBeTruthy();
+    });
+
+    it('should trigger change on track press', () => {
+        const changeSpy = jasmine.createSpy("onChange");
+        const props = {
+            min: 1,
+            onChange: changeSpy
+        };
+
+        render(props);
+
+        const track = root.find('.k-slider-track')[0];
+        const tick = root.find('.k-tick').first();
+
+        track.dispatchEvent(new MouseEvent('mousedown', {
+            bubbles: true,
+            clientX: tick.offset().left,
+            clientY: tick.offset().top
+        }));
+
+        expect(changeSpy).toHaveBeenCalledWith({ value: props.min });
+    });
+
+    it('should trigger change on handle drag', () => {
+        const changeSpy = jasmine.createSpy("onChange");
+        const props = {
+            min: 0,
+            max: 3,
+            value: 0,
+            onChange: changeSpy
+        };
+
+        render(props);
+
+        const track = root.find('.k-slider-track')[0];
+        const tick = root.find('.k-tick');
+
+        track.dispatchEvent(new MouseEvent('mousedown', {
+            bubbles: true,
+            clientX: tick.first().offset().left,
+            clientY: tick.first().offset().top
+        }));
+
+        document.dispatchEvent(new MouseEvent('mousemove', {
+            bubbles: true,
+            clientX: tick.eq(1).offset().left + 40,
+            clientY: tick.eq(1).offset().top
+        }));
+
+        expect(changeSpy).toHaveBeenCalledWith({ value: 1 });
     });
 }));

--- a/examples/draggable.html
+++ b/examples/draggable.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <div style="width: 2000px; height: 2000px; touch-action: pan-y">
+        <div id="app"></div>
+    </div>
+    <script src="draggable.js"></script>
+</body>
+</html>

--- a/examples/draggable.jsx
+++ b/examples/draggable.jsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import ReactDOM from 'react-dom';
+import Draggable from "../src/Draggable";
+
+class DraggableDiv extends React.Component {
+    componentDidMount() {
+        this.d = new Draggable(this.el, {
+            press: (e) => { console.log("press", e) },
+            drag: (e) => { console.log("drag", e) },
+            release: (e) => { console.log("release", e) }
+        });
+    }
+
+    render() {
+        return (
+            <div
+                ref={(c) => this.el = c}
+                style={{ width: 399, height: 400, background: "red" }}
+            ></div>);
+    }
+}
+ReactDOM.render(
+    <DraggableDiv />,
+    document.getElementById('app')
+);

--- a/src/Draggable.jsx
+++ b/src/Draggable.jsx
@@ -1,0 +1,100 @@
+const proxy = (a, b) => (e) => b(a(e));
+
+const bind = (el, event, callback) =>
+    el.addEventListener(event, callback);
+
+const unbind = (el, event, callback) =>
+    el.removeEventListener(event, callback);
+
+const touchRegExp = /touch/;
+
+function normalizeEvent(e) {
+    if (e.type.match(touchRegExp)) {
+        return {
+            pageX: e.changedTouches[0].pageX,
+            pageY: e.changedTouches[0].pageY,
+            type: e.type
+        };
+    }
+
+    return {
+        pageX: e.pageX,
+        pageY: e.pageY,
+        type: e.type
+    };
+}
+
+const noop = function() { };
+
+// 300ms is the usual mouse interval;
+// However, a weak mobile device under a heavy load may queue mouse events for longer.
+const IGNORE_MOUSE_TIMEOUT = 2000;
+
+export default class Draggable {
+    constructor(element, { press = noop, drag = noop, release = noop }) {
+        this._pressHandler = proxy(normalizeEvent, press);
+        this._dragHandler = proxy(normalizeEvent, drag);
+        this._releaseHandler = proxy(normalizeEvent, release);
+
+        this._element = element;
+        this._ignoreMouse = false;
+
+        bind(element, "mousedown", this._mousedown);
+        bind(element, "touchstart", this._touchstart);
+        bind(element, "touchmove", this._touchmove);
+        bind(element, "touchend", this._touchend);
+    }
+
+    _touchstart = (e) => {
+        if (e.touches.length === 1) {
+            this._pressHandler(e);
+        }
+    };
+
+    _touchmove = (e) => {
+        if (e.touches.length === 1) {
+            this._dragHandler(e);
+        }
+    };
+
+    _touchend = (e) => {
+        // the last finger has been lifted, and the user is not doing gesture.
+        // there might be a better way to handle this.
+        if (e.touches.length === 0 && e.changedTouches.length === 1) {
+            this._releaseHandler(e);
+            this._ignoreMouse = true;
+            setTimeout(this._restoreMouse, IGNORE_MOUSE_TIMEOUT);
+        }
+    };
+
+    _restoreMouse = () =>
+        this._ignoreMouse = false;
+
+    _mousedown = (e) => {
+        if (!this._ignoreMouse) {
+            bind(document, "mousemove", this._mousemove);
+            bind(document, "mouseup", this._mouseup);
+            this._pressHandler(e);
+        }
+    };
+
+    _mousemove = (e) => {
+        this._dragHandler(e);
+    };
+
+    _mouseup = (e) => {
+        unbind(document, "mousemove", this._mousemove);
+        unbind(document, "mouseup", this._mouseup);
+        this._releaseHandler(e);
+    };
+
+    destroy() {
+        unbind(this._element, "mousedown", this._mousedown);
+        unbind(this._element, "touchstart", this._touchstart);
+        unbind(this._element, "touchmove", this._touchmove);
+        unbind(this._element, "touchend", this._touchend);
+
+        this._element = null;
+    }
+}
+

--- a/src/Draggable.jsx
+++ b/src/Draggable.jsx
@@ -67,8 +67,9 @@ export default class Draggable {
         }
     };
 
-    _restoreMouse = () =>
+    _restoreMouse = () => {
         this._ignoreMouse = false;
+    };
 
     _mousedown = (e) => {
         if (!this._ignoreMouse) {

--- a/src/slider/Slider.jsx
+++ b/src/slider/Slider.jsx
@@ -74,11 +74,25 @@ class Slider extends React.Component {
         this.props.onChange({ value });
     };
 
-    onTrackClick = (event) => {
-        const trackClientRect = event.currentTarget.getBoundingClientRect();
-        const value = util.calculateValueFromTrack(trackClientRect, event, this.props);
+    onTrackPress = (event) => {
+        this.trackClientRect = event.currentTarget.getBoundingClientRect();
+        const value = util.calculateValueFromTrack(this.trackClientRect, event, this.props);
 
         this.props.onChange({ value: value });
+
+        document.addEventListener("mousemove", this.handleTrackDrag);
+        document.addEventListener("mouseup", this.handleTrackDrop);
+    };
+
+    handleTrackDrag = (event) => {
+        const value = util.calculateValueFromTrack(this.trackClientRect, event, this.props);
+
+        this.props.onChange({ value: value });
+    };
+
+    handleTrackDrop = () => {
+        document.removeEventListener("mousemove", this.handleTrackDrag);
+        document.removeEventListener("mouseup", this.handleTrackDrop);
     };
 
     onKeyDown = (event) => {
@@ -119,7 +133,7 @@ class Slider extends React.Component {
             dragHandleTitle,
             max,
             min,
-            onClick: this.onTrackClick,
+            onMouseDown: this.onTrackPress,
             onKeyDown: this.onKeyDown,
             value,
             disabled

--- a/src/slider/Slider.jsx
+++ b/src/slider/Slider.jsx
@@ -27,12 +27,24 @@ const propTypes = {
 };
 
 class Slider extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            pressed: false
+        };
+    }
+
     componentDidMount() {
         this.sizeComponent();
     }
 
     componentDidUpdate() {
         this.sizeComponent();
+    }
+
+    componentWillUnmount() {
+        this.removeDocumentListener();
     }
 
     sizeComponent() {
@@ -51,6 +63,23 @@ class Slider extends React.Component {
 
         if (this.props.fixedTickWidth) {
             model.resizeWrapper();
+        }
+    }
+
+    documentEvents = {
+        mousemove: this.handleTrackDrag,
+        mouseup: this.handleTrackDrop
+    };
+
+    addDocumentListener() {
+        for (const event in this.documentEvents) {
+            document.addEventListener(event, this.documentEvents[event]);
+        }
+    }
+
+    removeDocumentListener() {
+        for (const event in this.documentEvents) {
+            document.removeEventListener(event, this.documentEvents[event]);
         }
     }
 
@@ -78,10 +107,13 @@ class Slider extends React.Component {
         this.trackClientRect = event.currentTarget.getBoundingClientRect();
         const value = util.calculateValueFromTrack(this.trackClientRect, event, this.props);
 
+        this.setState({
+            pressed: true
+        });
+
         this.props.onChange({ value: value });
 
-        document.addEventListener("mousemove", this.handleTrackDrag);
-        document.addEventListener("mouseup", this.handleTrackDrop);
+        this.addDocumentListener();
     };
 
     handleTrackDrag = (event) => {
@@ -91,8 +123,11 @@ class Slider extends React.Component {
     };
 
     handleTrackDrop = () => {
-        document.removeEventListener("mousemove", this.handleTrackDrag);
-        document.removeEventListener("mouseup", this.handleTrackDrop);
+        this.setState({
+            pressed: false
+        });
+
+        this.removeDocumentListener();
     };
 
     onKeyDown = (event) => {
@@ -133,6 +168,7 @@ class Slider extends React.Component {
             dragHandleTitle,
             max,
             min,
+            pressed: this.state.pressed,
             onMouseDown: this.onTrackPress,
             onKeyDown: this.onKeyDown,
             value,

--- a/src/slider/Slider.jsx
+++ b/src/slider/Slider.jsx
@@ -66,21 +66,14 @@ class Slider extends React.Component {
         }
     }
 
-    documentEvents = {
-        mousemove: this.handleTrackDrag,
-        mouseup: this.handleTrackDrop
-    };
-
     addDocumentListener() {
-        for (const event in this.documentEvents) {
-            document.addEventListener(event, this.documentEvents[event]);
-        }
+        document.addEventListener("mousemove", this.handleTrackDrag);
+        document.addEventListener("mouseup", this.handleTrackDrop);
     }
 
     removeDocumentListener() {
-        for (const event in this.documentEvents) {
-            document.removeEventListener(event, this.documentEvents[event]);
-        }
+        document.removeEventListener("mousemove", this.handleTrackDrag);
+        document.removeEventListener("mouseup", this.handleTrackDrop);
     }
 
     onIncrease = () => {

--- a/src/slider/SliderTrack.jsx
+++ b/src/slider/SliderTrack.jsx
@@ -22,6 +22,11 @@ const SliderTrack = ({ onMouseDown, pressed, disabled, max, min, value, onKeyDow
         [styles.pressed]: pressed
     });
 
+    const selectionClasses = classnames({
+        [styles["slider-selection"]]: true,
+        [styles.pressed]: pressed
+    });
+
     const preventHandleClick = (event) => event.preventDefault();
 
     if (!disabled) {
@@ -32,7 +37,7 @@ const SliderTrack = ({ onMouseDown, pressed, disabled, max, min, value, onKeyDow
 
     return (
         <div {...trackProps}>
-            <div className={styles["slider-selection"]}></div>
+            <div className={selectionClasses}></div>
             <a className={handleClasses} {...attributes}
                 onClick={preventHandleClick}
                 onKeyDown={onKeyDown}

--- a/src/slider/SliderTrack.jsx
+++ b/src/slider/SliderTrack.jsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import styles from '@telerik/kendo-theme-default/styles/slider/main';
+import classnames from 'classnames';
 
-const SliderTrack = ({ onMouseDown, disabled, max, min, value, onKeyDown, dragHandleTitle = 'Drag' }) => {
+const SliderTrack = ({ onMouseDown, pressed, disabled, max, min, value, onKeyDown, dragHandleTitle = 'Drag' }) => {
     const attributes = {
         'title': dragHandleTitle,
         'tabIndex': 0,
@@ -16,6 +17,11 @@ const SliderTrack = ({ onMouseDown, disabled, max, min, value, onKeyDown, dragHa
         className: styles["slider-track"]
     };
 
+    const handleClasses = classnames({
+        [styles.draghandle]: true,
+        [styles.pressed]: pressed
+    });
+
     const preventHandleClick = (event) => event.preventDefault();
 
     if (!disabled) {
@@ -27,7 +33,7 @@ const SliderTrack = ({ onMouseDown, disabled, max, min, value, onKeyDown, dragHa
     return (
         <div {...trackProps}>
             <div className={styles["slider-selection"]}></div>
-            <a className={styles.draghandle} {...attributes}
+            <a className={handleClasses} {...attributes}
                 onClick={preventHandleClick}
                 onKeyDown={onKeyDown}
             ></a>

--- a/src/slider/SliderTrack.jsx
+++ b/src/slider/SliderTrack.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@telerik/kendo-theme-default/styles/slider/main';
 
-const SliderTrack = ({ onClick, disabled, max, min, value, onKeyDown, dragHandleTitle = 'Drag' }) => {
+const SliderTrack = ({ onMouseDown, disabled, max, min, value, onKeyDown, dragHandleTitle = 'Drag' }) => {
     const attributes = {
         'title': dragHandleTitle,
         'tabIndex': 0,
@@ -16,19 +16,19 @@ const SliderTrack = ({ onClick, disabled, max, min, value, onKeyDown, dragHandle
         className: styles["slider-track"]
     };
 
+    const preventHandleClick = (event) => event.preventDefault();
+
     if (!disabled) {
         Object.assign(trackProps, {
-            onClick: onClick
+            onMouseDown: onMouseDown
         });
     }
-
-    const onHandleClick = (event) => event.preventDefault();
 
     return (
         <div {...trackProps}>
             <div className={styles["slider-selection"]}></div>
-            <a className={styles.draghandle} {...attributes} href="#"
-                onClick={onHandleClick}
+            <a className={styles.draghandle} {...attributes}
+                onClick={preventHandleClick}
                 onKeyDown={onKeyDown}
             ></a>
         </div>

--- a/test/slider/SliderTrack.jsx
+++ b/test/slider/SliderTrack.jsx
@@ -22,10 +22,10 @@ describe('SliderTrack', () => {
         expect(draghandle.hasClass('k-draghandle')).toBe(true);
     });
 
-    it('should propagate draghandle click', () => {
-        let spy = jasmine.createSpy('click');
-        let result = shallow(<SliderTrack onClick={spy} />);
-        result.simulate('click');
+    it('should propagate draghandle mousedown', () => {
+        let spy = jasmine.createSpy('mousedown');
+        let result = shallow(<SliderTrack onMouseDown={spy} />);
+        result.simulate('mousedown');
         expect(spy).toHaveBeenCalled();
     });
 

--- a/test/slider/SliderTrack.jsx
+++ b/test/slider/SliderTrack.jsx
@@ -4,33 +4,53 @@ import SliderTrack from '../../src/slider/SliderTrack';
 
 describe('SliderTrack', () => {
     it('should render a div', () => {
-        let result = shallow(<SliderTrack />);
+        const result = shallow(<SliderTrack />);
+
         expect(result.type()).toEqual('div');
     });
 
     it('should render a selection', () => {
-        let result = shallow(<SliderTrack />);
+        const result = shallow(<SliderTrack />);
         const selection = result.children().first();
+
         expect(selection.type()).toEqual('div');
         expect(selection.hasClass('k-slider-selection')).toBe(true);
     });
 
     it('should render a draghandle', () => {
-        let result = shallow(<SliderTrack />);
+        const result = shallow(<SliderTrack />);
         const draghandle = result.children().last();
+
         expect(draghandle.type()).toEqual('a');
         expect(draghandle.hasClass('k-draghandle')).toBe(true);
     });
 
     it('should propagate draghandle mousedown', () => {
-        let spy = jasmine.createSpy('mousedown');
-        let result = shallow(<SliderTrack onMouseDown={spy} />);
+        const spy = jasmine.createSpy('mousedown');
+        const result = shallow(<SliderTrack onMouseDown={spy} />);
+
         result.simulate('mousedown');
+
         expect(spy).toHaveBeenCalled();
     });
 
     it('should not attach click handler when disabled', () => {
-        let result = shallow(<SliderTrack disabled/>);
+        const result = shallow(<SliderTrack disabled/>);
+
         expect(result.props().onClick).toBe(undefined);
+    });
+
+    it('should render pressed style', () => {
+        const result = shallow(<SliderTrack pressed />);
+        const draghandle = result.children().last();
+
+        expect(draghandle.hasClass('k-pressed')).toBe(true);
+    });
+
+    it('should not render pressed style if not pressed', () => {
+        const result = shallow(<SliderTrack />);
+        const draghandle = result.children().last();
+
+        expect(draghandle.hasClass('k-pressed')).toBe(false);
     });
 });


### PR DESCRIPTION
Add support for drag and drop of Slider handle. Closes #2 .

The implementation is based on the abstraction [discussed here](https://github.com/telerik/kendo-react-inputs/issues/22).